### PR TITLE
Add missing export for createReducer (fix #6)

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export {configureStore, createDefaultMiddleware} from "./configureStore";
+export {createReducer} from "./createReducer";
 
 export {default as createNextState} from "immer";
 export {combineReducers} from "redux";


### PR DESCRIPTION
This should be enough, but I still can't use `import {createReducer} from "@acemarke/redux-starter-kit";` in CRA even after linking the module and building it. Any ideas?