### PR TITLE
Pass error/meta to case reducers, support non-FSAs

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,33 +2,36 @@
 
 **A simple set of tools to make using Redux easier**
 
-[NPM: @acemarke/redux-starter-kit](https://www.npmjs.com/package/@acemarke/redux-starter-kit)
+[NPM:  @acemarke/redux-starter-kit](https://www.npmjs.com/package/@acemarke/redux-starter-kit)
 
 ### Purpose
 
 The `redux-starter-kit` package is intended to help address three common complaints about Redux:
 
-* "Configuring a Redux store is too complicated"
-* "I have to add a lot of packages to get Redux to do anything useful"
-* "Redux requires too much boilerplate code"
+- "Configuring a Redux store is too complicated"
+- "I have to add a lot of packages to get Redux to do anything useful"
+- "Redux requires too much boilerplate code"
 
 We can't solve every use case, but in the spirit of [`create-react-app`](https://github.com/facebook/create-react-app) and [`apollo-boost`](https://dev-blog.apollodata.com/zero-config-graphql-state-management-27b1f1b3c2c3), we can try to provide some tools that abstract over the setup process and handle the most common use cases, as well as include some useful utilities that will let the user simplify their application code.
 
-This package is _not_ intended to solve every possible complaint about Redux, and is deliberately limited in scope. It does _not_ address concepts like "reusable encapsulated Redux modules", data fetching, folder or file structures, managing entity relationships in the store, and so on.
+This package is _not_ intended to solve every possible complaint about Redux, and is deliberately limited in scope.  It does _not_ address concepts like "reusable encapsulated Redux modules", data fetching, folder or file structures, managing entity relationships in the store, and so on.
+
 
 ### What's Included
 
 `redux-starter-kit` includes:
 
-* A `configureStore()` function with simplified configuration options. It can automatically combine your slice reducers, adds whatever Redux middleware you supply, includes `redux-thunk` by default, and enables use of the Redux DevTools Extension.
-* A `createReducer()` utility that lets you supply a lookup table of action types to case reducer functions, rather than writing switch statements. In addition, it automatically uses the [`immer` library](https://github.com/mweststrate/immer) to let you write simpler immutable updates with normal mutative code, like `state.todos[3].completed = true`.
-* An improved version of the widely used `createSelector` utility for creating memoized selector functions, which can accept string keypaths as "input selectors" (re-exported from the [`selectorator` library](https://github.com/planttheidea/selectorator)).
+- A `configureStore()` function with simplified configuration options.  It can automatically combine your slice reducers, adds whatever Redux middleware you supply, includes `redux-thunk` by default, and enables use of the Redux DevTools Extension.
+- A `createReducer()` utility that lets you supply a lookup table of action types to case reducer functions, rather than writing switch statements.  In addition, it automatically uses the [`immer` library](https://github.com/mweststrate/immer) to let you write simpler immutable updates with normal mutative code, like `state.todos[3].completed = true`.
+- An improved version of the widely used `createSelector` utility for creating memoized selector functions, which can accept string keypaths as "input selectors" (re-exported from the [`selectorator` library](https://github.com/planttheidea/selectorator)).
+
 
 ### API Reference
 
+
 #### `configureStore`
 
-A friendlier abstraction over the standard Redux `createStore` function. Takes a single configuration object parameter, with the following options:
+A friendlier abstraction over the standard Redux `createStore` function.  Takes a single configuration object parameter, with the following options:
 
 ```js
 function configureStore({
@@ -46,10 +49,11 @@ function configureStore({
 })
 ```
 
+
 Basic usage:
 
 ```js
-import { configureStore } from "@acemarke/redux-starter-kit";
+import {configureStore} from "@acemarke/redux-starter-kit";
 
 import rootReducer from "./reducers";
 
@@ -60,47 +64,42 @@ const store = configureStore(rootReducer);
 Full example:
 
 ```js
-import {
-  configureStore,
-  createDefaultMiddleware
-} from "@acemarke/redux-starter-kit";
+import {configureStore, createDefaultMiddleware} from "@acemarke/redux-starter-kit";
 
 // We'll use redux-logger just as an example of adding another middleware
 import logger from "redux-logger";
 
 // And use redux-batch as an example of adding enhancers
-import { reduxBatch } from "@manaflair/redux-batch";
+import { reduxBatch }  from '@manaflair/redux-batch';
 
 import todosReducer from "./todos/todosReducer";
 import visibilityReducer from "./visibility/visibilityReducer";
 
 const reducer = {
-  todos: todosReducer,
-  visibility: visibilityReducer
+    todos : todosReducer,
+    visibility : visibilityReducer
 };
 
 const middleware = createDefaultMiddleware(logger);
 
 const preloadedState = {
-  todos: [
-    {
-      text: "Eat food",
-      completed: true
-    },
-    {
-      text: "Exercise",
-      completed: false
-    }
-  ],
-  visibilityFilter: "SHOW_COMPLETED"
+    todos: [{
+        text: 'Eat food',
+        completed: true
+    }, {
+        text: 'Exercise',
+        completed: false
+    }],
+    visibilityFilter : 'SHOW_COMPLETED'
 };
 
+
 const store = configureStore({
-  reducer,
-  middleware,
-  devTools: NODE_ENV !== "production",
-  preloadedState,
-  enhancers: [reduxBatch]
+    reducer,
+    middleware,
+    devTools : NODE_ENV !== 'production',
+    preloadedState,
+    enhancers : [reduxBatch],
 });
 
 // The store has been created with these options:
@@ -110,38 +109,35 @@ const store = configureStore({
 // - The middleware, batch, and devtools enhancers were automatically composed together
 ```
 
+
 #### `createReducer`
 
-A utility function to create reducers that handle specific action types, similar to the example function in the ["Reducing Boilerplate" Redux docs page](https://redux.js.org/recipes/reducing-boilerplate#generating-reducers). Takes an initial state value and an object that maps action types to case reducer functions. Internally, it uses the [`immer` library](), so you can write code in your case reducers that mutates the existing `state` value, and it will correctly generate immutably-updated state values instead.
+A utility function to create reducers that handle specific action types, similar to the example function in the ["Reducing Boilerplate" Redux docs page](https://redux.js.org/recipes/reducing-boilerplate#generating-reducers).  Takes an initial state value and an object that maps action types to case reducer functions.  Internally, it uses the [`immer` library](), so you can write code in your case reducers that mutates the existing `state` value, and it will correctly generate immutably-updated state values instead.
 
 ```js
-function createReducer(
-  initialState: State,
-  actionsMap: Object<String, Function>
-) {}
+function createReducer(initialState : State, actionsMap : Object<String, Function>) {}
 ```
 
 Example usage:
-
 ```js
-import { createReducer } from "@acemarke/redux-starter-kit";
+import {createReducer} from "@acemarke/redux-starter-kit";
 
 function addTodo(state, newTodo) {
-  // Can safely call state.push() here
-  state.push({ ...newTodo, completed: false });
+    // Can safely call state.push() here
+    state.push({...newTodo, completed : false});
 }
 
 function toggleTodo(state, payload) {
-  const { index } = payload;
+    const {index} = payload;
 
-  const todo = state[index];
-  // Can directly modify the todo object
-  todo.completed = !todo.completed;
+    const todo = state[index];
+    // Can directly modify the todo object
+    todo.completed = !todo.completed;
 }
 
 const todosReducer = createReducer([], {
-  ADD_TODO: addTodo,
-  TOGGLE_TODO: toggleTodo
+    ADD_TODO : addTodo,
+    TOGGLE_TODO : toggleTodo
 });
 ```
 
@@ -181,7 +177,7 @@ const addInvoiceCaseReducer = (state, { date, dueDate, amount }) =>
 
 #### `createSelector`
 
-The `createSelector` utility from the [`selectorator` library](https://github.com/planttheidea/selectorator), re-exported for ease of use. It acts as a superset of the standard `createSelector` function from [Reselect](https://github.com/reactjs/reselect). The primary improvements are the ability to define "input selectors" using string keypaths, or return an object result based on an object of keypaths. It also accepts an object of customization options for more specific use cases.
+The `createSelector` utility from the [`selectorator` library](https://github.com/planttheidea/selectorator), re-exported for ease of use.  It acts as a superset of the standard `createSelector` function from [Reselect](https://github.com/reactjs/reselect).  The primary improvements are the ability to define "input selectors" using string keypaths, or return an object result based on an object of keypaths.  It also accepts an object of customization options for more specific use cases.
 
 For more specifics, see the [`selectorator` usage documentation](https://github.com/planttheidea/selectorator#usage).
 
@@ -198,21 +194,20 @@ Example usage:
 
 ```js
 // Define input selector using a string keypath
-const getSubtotal = createSelector(["shop.items"], items => {
+const getSubtotal = createSelector(['shop.items'], (items) => {
   // return value here
 });
 
 // Define input selectors as a mix of other selectors and string keypaths
-const getTax = createSelector(
-  [getSubtotal, "shop.taxPercent"],
-  (subtotal, taxPercent) => {
-    // return value here
-  }
-);
+const getTax = createSelector([getSubtotal, 'shop.taxPercent'], (subtotal, taxPercent) => {
+  // return value here
+});
 
-const getContents = createSelector({ foo: "foo", bar: "nested.bar" });
+const getContents = createSelector({foo : "foo", bar : "nested.bar" });
 // Returns an object like:  {foo, bar}
+
 ```
+
 
 #### `createNextState`
 

--- a/README.md
+++ b/README.md
@@ -145,12 +145,13 @@ const todosReducer = createReducer([], {
 
 ```js
 const notifications = (state, payload, { error, meta }) => {
-  // As stated by FSA docs, by convention, if error is true, the payload SHOULD be an error object
+  // As stated by FSA docs, by convention, if error is true, the payload SHOULD be an error object.
   if (payload instanceof Error) {
     state.push({ intent: "danger", message: payload.message });
   }
   
-  // If you don't want to follow this convention, you can use the error and meta properties
+  // You can also use the error and meta properties, they are useful if you don't want to follow this convention.
+  // (Of course you are free to use those properties for other use cases. Error handling is just an example.)
   if (error) {
     state.push({ intent: meta.intent, message: payload });
   }

--- a/README.md
+++ b/README.md
@@ -141,27 +141,23 @@ const todosReducer = createReducer([], {
 });
 ```
 
-`createReducer` supports [Flux Standand Actions (FSA)](https://github.com/redux-utilities/flux-standard-action).
+`createReducer` supports [Flux Standand Actions (FSA)](https://github.com/redux-utilities/flux-standard-action):
 
 ```js
-// As stated by FSA docs, by convention, if error is true, the payload SHOULD be an error object
-const notifications = (state, payload) => {
-  if (payload instanceof Error) {
-    return state.push({ intent: "danger", message: payload.message });
-  }
-  return state;
-};
-
-// You can also read error and meta properties, it's useful if you don't want to follow all FSA conventions
 const notifications = (state, payload, { error, meta }) => {
-  if (error) {
-    return state.push({ intent: meta.intent, message: payload });
+  // As stated by FSA docs, by convention, if error is true, the payload SHOULD be an error object
+  if (payload instanceof Error) {
+    state.push({ intent: "danger", message: payload.message });
   }
-  return state;
+  
+  // If you don't want to follow this convention, you can use the error and meta properties
+  if (error) {
+    state.push({ intent: meta.intent, message: payload });
+  }
 };
 ```
 
-If you don't want to use FSA in your project, that's not an issue:
+If you don't use FSA in your project, that's not an issue:
 
 ```js
 const addInvoice = (date, dueDate, amount) => ({

--- a/README.md
+++ b/README.md
@@ -2,36 +2,33 @@
 
 **A simple set of tools to make using Redux easier**
 
-[NPM:  @acemarke/redux-starter-kit](https://www.npmjs.com/package/@acemarke/redux-starter-kit)
+[NPM: @acemarke/redux-starter-kit](https://www.npmjs.com/package/@acemarke/redux-starter-kit)
 
 ### Purpose
 
 The `redux-starter-kit` package is intended to help address three common complaints about Redux:
 
-- "Configuring a Redux store is too complicated"
-- "I have to add a lot of packages to get Redux to do anything useful"
-- "Redux requires too much boilerplate code"
+* "Configuring a Redux store is too complicated"
+* "I have to add a lot of packages to get Redux to do anything useful"
+* "Redux requires too much boilerplate code"
 
 We can't solve every use case, but in the spirit of [`create-react-app`](https://github.com/facebook/create-react-app) and [`apollo-boost`](https://dev-blog.apollodata.com/zero-config-graphql-state-management-27b1f1b3c2c3), we can try to provide some tools that abstract over the setup process and handle the most common use cases, as well as include some useful utilities that will let the user simplify their application code.
 
-This package is _not_ intended to solve every possible complaint about Redux, and is deliberately limited in scope.  It does _not_ address concepts like "reusable encapsulated Redux modules", data fetching, folder or file structures, managing entity relationships in the store, and so on.  
-
+This package is _not_ intended to solve every possible complaint about Redux, and is deliberately limited in scope. It does _not_ address concepts like "reusable encapsulated Redux modules", data fetching, folder or file structures, managing entity relationships in the store, and so on.
 
 ### What's Included
 
 `redux-starter-kit` includes:
 
-- A `configureStore()` function with simplified configuration options.  It can automatically combine your slice reducers, adds whatever Redux middleware you supply, includes `redux-thunk` by default, and enables use of the Redux DevTools Extension.
-- A `createReducer()` utility that lets you supply a lookup table of action types to case reducer functions, rather than writing switch statements.  In addition, it automatically uses the [`immer` library](https://github.com/mweststrate/immer) to let you write simpler immutable updates with normal mutative code, like `state.todos[3].completed = true`.
-- An improved version of the widely used `createSelector` utility for creating memoized selector functions, which can accept string keypaths as "input selectors" (re-exported from the [`selectorator` library](https://github.com/planttheidea/selectorator)).
-
+* A `configureStore()` function with simplified configuration options. It can automatically combine your slice reducers, adds whatever Redux middleware you supply, includes `redux-thunk` by default, and enables use of the Redux DevTools Extension.
+* A `createReducer()` utility that lets you supply a lookup table of action types to case reducer functions, rather than writing switch statements. In addition, it automatically uses the [`immer` library](https://github.com/mweststrate/immer) to let you write simpler immutable updates with normal mutative code, like `state.todos[3].completed = true`.
+* An improved version of the widely used `createSelector` utility for creating memoized selector functions, which can accept string keypaths as "input selectors" (re-exported from the [`selectorator` library](https://github.com/planttheidea/selectorator)).
 
 ### API Reference
 
-
 #### `configureStore`
 
-A friendlier abstraction over the standard Redux `createStore` function.  Takes a single configuration object parameter, with the following options:
+A friendlier abstraction over the standard Redux `createStore` function. Takes a single configuration object parameter, with the following options:
 
 ```js
 function configureStore({
@@ -49,11 +46,10 @@ function configureStore({
 })
 ```
 
-
 Basic usage:
 
 ```js
-import {configureStore} from "@acemarke/redux-starter-kit";
+import { configureStore } from "@acemarke/redux-starter-kit";
 
 import rootReducer from "./reducers";
 
@@ -64,42 +60,47 @@ const store = configureStore(rootReducer);
 Full example:
 
 ```js
-import {configureStore, createDefaultMiddleware} from "@acemarke/redux-starter-kit";
+import {
+  configureStore,
+  createDefaultMiddleware
+} from "@acemarke/redux-starter-kit";
 
 // We'll use redux-logger just as an example of adding another middleware
 import logger from "redux-logger";
 
 // And use redux-batch as an example of adding enhancers
-import { reduxBatch }  from '@manaflair/redux-batch';
+import { reduxBatch } from "@manaflair/redux-batch";
 
 import todosReducer from "./todos/todosReducer";
 import visibilityReducer from "./visibility/visibilityReducer";
 
 const reducer = {
-    todos : todosReducer,
-    visibility : visibilityReducer
+  todos: todosReducer,
+  visibility: visibilityReducer
 };
 
 const middleware = createDefaultMiddleware(logger);
 
 const preloadedState = {
-    todos: [{
-        text: 'Eat food',
-        completed: true
-    }, {
-        text: 'Exercise',
-        completed: false
-    }],
-    visibilityFilter : 'SHOW_COMPLETED'
+  todos: [
+    {
+      text: "Eat food",
+      completed: true
+    },
+    {
+      text: "Exercise",
+      completed: false
+    }
+  ],
+  visibilityFilter: "SHOW_COMPLETED"
 };
 
-
 const store = configureStore({
-    reducer,
-    middleware,
-    devTools : NODE_ENV !== 'production',
-    preloadedState,
-    enhancers : [reduxBatch],
+  reducer,
+  middleware,
+  devTools: NODE_ENV !== "production",
+  preloadedState,
+  enhancers: [reduxBatch]
 });
 
 // The store has been created with these options:
@@ -109,43 +110,78 @@ const store = configureStore({
 // - The middleware, batch, and devtools enhancers were automatically composed together
 ```
 
-
 #### `createReducer`
 
-A utility function to create reducers that handle specific action types, similar to the example function in the ["Reducing Boilerplate" Redux docs page](https://redux.js.org/recipes/reducing-boilerplate#generating-reducers).  Takes an initial state value and an object that maps action types to case reducer functions.  Internally, it uses the [`immer` library](), so you can write code in your case reducers that mutates the existing `state` value, and it will correctly generate immutably-updated state values instead.
+A utility function to create reducers that handle specific action types, similar to the example function in the ["Reducing Boilerplate" Redux docs page](https://redux.js.org/recipes/reducing-boilerplate#generating-reducers). Takes an initial state value and an object that maps action types to case reducer functions. Internally, it uses the [`immer` library](), so you can write code in your case reducers that mutates the existing `state` value, and it will correctly generate immutably-updated state values instead.
 
 ```js
-function createReducer(initialState : State, actionsMap : Object<String, Function>) {}
+function createReducer(
+  initialState: State,
+  actionsMap: Object<String, Function>
+) {}
 ```
 
 Example usage:
+
 ```js
-import {createReducer} from "@acemarke/redux-starter-kit";
+import { createReducer } from "@acemarke/redux-starter-kit";
 
 function addTodo(state, newTodo) {
-    // Can safely call state.push() here
-    state.push({...newTodo, completed : false});
+  // Can safely call state.push() here
+  state.push({ ...newTodo, completed: false });
 }
 
 function toggleTodo(state, payload) {
-    const {index} = payload;
+  const { index } = payload;
 
-    const todo = state[index];
-    // Can directly modify the todo object
-    todo.completed = !todo.completed;
+  const todo = state[index];
+  // Can directly modify the todo object
+  todo.completed = !todo.completed;
 }
 
 const todosReducer = createReducer([], {
-    ADD_TODO : addTodo,
-    TOGGLE_TODO : toggleTodo
+  ADD_TODO: addTodo,
+  TOGGLE_TODO: toggleTodo
 });
 ```
 
+`createReducer` supports [Flux Standand Actions (FSA)](https://github.com/redux-utilities/flux-standard-action).
 
+```js
+// As stated by FSA docs, by convention, if error is true, the payload SHOULD be an error object
+const notifications = (state, payload) => {
+  if (payload instanceof Error) {
+    return state.push({ intent: "danger", message: payload.message });
+  }
+  return state;
+};
+
+// You can also read error and meta properties, it's useful if you don't want to follow all FSA conventions
+const notifications = (state, payload, { error, meta }) => {
+  if (error) {
+    return state.push({ intent: meta.intent, message: payload });
+  }
+  return state;
+};
+```
+
+If you don't want to use FSA in your project, that's not an issue:
+
+```js
+const addInvoice = (date, dueDate, amount) => ({
+  type: ADD_INVOICE,
+  date,
+  dueDate,
+  amount
+});
+
+const addInvoiceCaseReducer = (state, { date, dueDate, amount }) =>
+  state.push({ date, dueDate, amount });
+```
 
 #### `createSelector`
 
-The `createSelector` utility from the [`selectorator` library](https://github.com/planttheidea/selectorator), re-exported for ease of use.  It acts as a superset of the standard `createSelector` function from [Reselect](https://github.com/reactjs/reselect).  The primary improvements are the ability to define "input selectors" using string keypaths, or return an object result based on an object of keypaths.  It also accepts an object of customization options for more specific use cases.
+The `createSelector` utility from the [`selectorator` library](https://github.com/planttheidea/selectorator), re-exported for ease of use. It acts as a superset of the standard `createSelector` function from [Reselect](https://github.com/reactjs/reselect). The primary improvements are the ability to define "input selectors" using string keypaths, or return an object result based on an object of keypaths. It also accepts an object of customization options for more specific use cases.
 
 For more specifics, see the [`selectorator` usage documentation](https://github.com/planttheidea/selectorator#usage).
 
@@ -162,20 +198,21 @@ Example usage:
 
 ```js
 // Define input selector using a string keypath
-const getSubtotal = createSelector(['shop.items'], (items) => {
+const getSubtotal = createSelector(["shop.items"], items => {
   // return value here
 });
 
 // Define input selectors as a mix of other selectors and string keypaths
-const getTax = createSelector([getSubtotal, 'shop.taxPercent'], (subtotal, taxPercent) => {
-  // return value here
-});
+const getTax = createSelector(
+  [getSubtotal, "shop.taxPercent"],
+  (subtotal, taxPercent) => {
+    // return value here
+  }
+);
 
-const getContents = createSelector({foo : "foo", bar : "nested.bar" });
+const getContents = createSelector({ foo: "foo", bar: "nested.bar" });
 // Returns an object like:  {foo, bar}
-
 ```
-
 
 #### `createNextState`
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "dist"
   ],
   "dependencies": {
+    "flux-standard-action": "^2.0.1",
     "immer": "^1.1.1",
     "redux": "^3.7.2",
     "redux-devtools-extension": "^2.13.2",

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -3,14 +3,15 @@ import { isFSA } from "flux-standard-action";
 
 export function createReducer(initialState, actionsMap) {
     return function(state = initialState, action) {
-        const {type, payload, ...rest} = action;
+        const {type, ...rest} = action;
 
         return createNextState(state, draft => {
             const caseReducer = actionsMap[type];
 
             if(caseReducer) {
                 if (isFSA(action)) {
-                    return caseReducer(draft, payload, rest);
+                    const {payload, error, meta} = rest
+                    return caseReducer(draft, payload, { error, meta });
                 }
 
                 return caseReducer(draft,  rest);

--- a/src/createReducer.js
+++ b/src/createReducer.js
@@ -1,14 +1,19 @@
 import createNextState from "immer";
+import { isFSA } from "flux-standard-action";
 
 export function createReducer(initialState, actionsMap) {
     return function(state = initialState, action) {
-        const {type, payload} = action;
+        const {type, payload, ...rest} = action;
 
         return createNextState(state, draft => {
             const caseReducer = actionsMap[type];
 
             if(caseReducer) {
-                return caseReducer(draft, payload);
+                if (isFSA(action)) {
+                    return caseReducer(draft, payload, rest);
+                }
+
+                return caseReducer(draft,  rest);
             }
 
             return draft;

--- a/yarn.lock
+++ b/yarn.lock
@@ -614,6 +614,12 @@ fill-range@^2.1.0:
     repeat-element "^1.1.2"
     repeat-string "^1.5.2"
 
+flux-standard-action@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/flux-standard-action/-/flux-standard-action-2.0.1.tgz#9e2947f5904edd48f9fab7516ddb8dea6f612075"
+  dependencies:
+    lodash "^4.0.0"
+
 for-in@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/for-in/-/for-in-1.0.2.tgz#81068d295a8142ec0ac726c6e2200c30fb6d5e80"

--- a/yarn.lock
+++ b/yarn.lock
@@ -776,7 +776,7 @@ lodash-es@^4.2.1:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash-es/-/lodash-es-4.17.5.tgz#9fc6e737b1c4d151d8f9cae2247305d552ce748f"
 
-lodash@^4.17.4, lodash@^4.2.1:
+lodash@^4.0.0, lodash@^4.17.4, lodash@^4.2.1:
   version "4.17.5"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.5.tgz#99a92d65c0272debe8c96b6057bc8fbfa3bed511"
 


### PR DESCRIPTION
I would like to suggest that we pass error/meta to case reducers:

```js
function myCaseReducer(state, payload, { error, meta }) {
    // ...
}
```

It might be useful.

Also I've added support to non-FSA.

Building is now failing, I don't know how to add support for rest spread in Rollup. Alternatively I could change the code to use `omit()`:

```js
const {type, payload} = action;
const rest = omit(action, ["type", "payload"])
```