### PR TITLE
docs(readme): add immutable example, add link to immer

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,11 +167,10 @@ function toggleTodo(state, action) {
 
     const todo = state[index];
     // Updates the todo object immutably withot relying on immer
-    return [
-        ...state.slice(0, index),
-        {...todo, completed: !todo.completed},
-        ...state.slice(index + 1),
-    ];
+    return state.map((todo, i) => {
+        if(i !== index) return todo;
+        return {...todo, completed : !todo.completed};
+    });
 }
 
 const todosReducer = createReducer([], {

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Adds redux-thunk to the given array of middlewares. Useful if you need to add cu
 
 #### `createReducer`
 
-A utility function to create reducers that handle specific action types, similar to the example function in the ["Reducing Boilerplate" Redux docs page](https://redux.js.org/recipes/reducing-boilerplate#generating-reducers).  Takes an initial state value and an object that maps action types to case reducer functions.  Internally, it uses the [`immer` library](), so you can write code in your case reducers that mutates the existing `state` value, and it will correctly generate immutably-updated state values instead.
+A utility function to create reducers that handle specific action types, similar to the example function in the ["Reducing Boilerplate" Redux docs page](https://redux.js.org/recipes/reducing-boilerplate#generating-reducers).  Takes an initial state value and an object that maps action types to case reducer functions.  Internally, it uses the [`immer` library](https://github.com/mweststrate/immer), so you can write code in your case reducers that mutates the existing `state` value, and it will correctly generate immutably-updated state values instead.
 
 ```js
 function createReducer(initialState : State, actionsMap : Object<String, Function>) {}
@@ -147,7 +147,38 @@ const todosReducer = createReducer([], {
     TOGGLE_TODO : toggleTodo
 });
 ```
+This doesn't mean that you *have to* write code in your case reducers that mutates the existing `state` value, you can still write code that updates the state immutably. You can think of `immer` as a safety net, if the code is written in a way that mutates the state directly, `immer` will make sure that such update happens immutably. On the other hand the following code is still valid:
 
+```js
+import {createReducer} from "@acemarke/redux-starter-kit";
+
+function addTodo(state, action) {
+    const {newTodo} = action.payload;
+
+    // Updates the state immutably without relying on immer
+    return [
+        ...state,
+        {...newTodo, completed : false},
+    ];
+}
+
+function toggleTodo(state, action) {
+    const {index} = action.payload;
+
+    const todo = state[index];
+    // Updates the todo object immutably withot relying on immer
+    return [
+        ...state.slice(0, index),
+        {...todo, completed: !todo.completed},
+        ...state.slice(index + 1),
+    ];
+}
+
+const todosReducer = createReducer([], {
+    ADD_TODO : addTodo,
+    TOGGLE_TODO : toggleTodo
+});
+```
 
 
 #### `createSelector`


### PR DESCRIPTION
This PR addresses the discussion at #5 . I noticed in the conversation was used a `.map` to update the state immutably, if you guys prefer that instead of slicing let me know and I will update the PR.