### PR TITLE
Update selectorator to support the new argIndex syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,9 +159,9 @@ For more specifics, see the [`selectorator` usage documentation](https://github.
 ```js
 function createSelector(
     // Can either be:
-    //    - An array containing selector functions and string keypaths
+    //    - An array containing selector functions, string keypaths, and argument objects
     //    - An object whose keys are selector functions and string keypaths
-    paths : Array<Function | string> | Object<string, string | Function>
+    paths : Array<Function | string | Object> | Object<string, string | Function>
 )
 ```
 
@@ -177,6 +177,11 @@ const getSubtotal = createSelector(['shop.items'], (items) => {
 const getTax = createSelector([getSubtotal, 'shop.taxPercent'], (subtotal, taxPercent) => {
   // return value here
 });
+
+// Define input selector using a custom argument index to access a prop
+const getTabContent = createSelector([{ path: 'tabIndex', argIndex: 1 }], (tabIndex) => {
+  // return value here
+})
 
 const getContents = createSelector({foo : "foo", bar : "nested.bar" });
 // Returns an object like:  {foo, bar}

--- a/package-lock.json
+++ b/package-lock.json
@@ -806,9 +806,9 @@
       }
     },
     "fast-equals": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-1.2.0.tgz",
-      "integrity": "sha512-e/hvHyVYaWiWMFRd5ZvYkseam5YLZjkkWuSFdnVxnD6Xc+V3H9aXwxvqhJvmmhMBWK8AAOs6OHhHVqr9aZCWiw=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-1.2.1.tgz",
+      "integrity": "sha512-7Rgsev90v//xCp60nlc1zjx6POzONKkCgAnId9qCUFONQ8r/Y/M2QQvAmy7mQyHBOHgp5t/lQvvJzKpM4YQvxA=="
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -1430,11 +1430,11 @@
       }
     },
     "selectorator": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/selectorator/-/selectorator-3.2.0.tgz",
-      "integrity": "sha512-qSfma5YFsvYAW4bFcRGY2WYQWpH373EMV/FGaXdfaK2ZhT2W8XVXNQpcDwcYYPkvz73NjPPboS39gErVtyHbNA==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/selectorator/-/selectorator-3.3.0.tgz",
+      "integrity": "sha512-GZX1biSrT1CpAeDaBjnRxbnjDys9JULX90jdxucESHkrOrKoVCYlw+ch5DDWlOuyI6Z/TxtsJXU5kaqchO7v+g==",
       "requires": {
-        "fast-equals": "1.2.0",
+        "fast-equals": "1.2.1",
         "identitate": "1.0.0",
         "reselect": "3.0.1",
         "unchanged": "1.0.7"

--- a/package.json
+++ b/package.json
@@ -30,6 +30,6 @@
     "redux": "^3.7.2",
     "redux-devtools-extension": "^2.13.2",
     "redux-thunk": "^2.2.0",
-    "selectorator": "^3.2.0"
+    "selectorator": "^3.3.0"
   }
 }


### PR DESCRIPTION
Unfortunately even if I `npm update selectorator` after installing `redux-starter-kit`, I still get stuck with version 3.2.0 when the package-lock.json says 3.3.0. It seems like in order to update re-exported dependencies, they have to be updated manually in redux-starter-kit and then the user has to update to the new version. In my opinion we should drop the re-exports in the long run, but this is a temporary workaround so I can use 3.3.0's new features in the example.