### PR TITLE
Remove re-exports

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,3 +181,58 @@ const todosReducer = createReducer([], {
   TOGGLE_TODO: toggleTodo
 })
 ```
+
+### Recommended Packages
+
+While `redux-starter-kit` automatically sets up a store for you with recommended middlewares and some additional helper functions, we have recommendations for optional packages that you may find useful in your Redux application code.
+
+#### [`selectorator`](https://github.com/planttheidea/selectorator)
+
+It acts as a superset of the standard `createSelector` function from [Reselect](https://github.com/reactjs/reselect). The primary improvements are the ability to define "input selectors" using string keypaths, or return an object result based on an object of keypaths. It also accepts an object of customization options for more specific use cases.
+
+For more specifics, see the [`selectorator` usage documentation](https://github.com/planttheidea/selectorator#usage).
+
+```js
+function createSelector(
+    // Can either be:
+    //    - An array containing selector functions, string keypaths, and argument objects
+    //    - An object whose keys are selector functions and string keypaths
+    paths : Array<Function | string | Object> | Object<string, string | Function>
+)
+```
+
+Example usage:
+
+```js
+// Define input selector using a string keypath
+const getSubtotal = createSelector(['shop.items'], items => {
+  // return value here
+})
+
+// Define input selectors as a mix of other selectors and string keypaths
+const getTax = createSelector(
+  [getSubtotal, 'shop.taxPercent'],
+  (subtotal, taxPercent) => {
+    // return value here
+  }
+)
+
+// Define input selector using a custom argument index to access a prop
+const getTabContent = createSelector(
+  [{ path: 'tabIndex', argIndex: 1 }],
+  tabIndex => {
+    // return value here
+  }
+)
+
+const getContents = createSelector({ foo: 'foo', bar: 'nested.bar' })
+// Returns an object like:  {foo, bar}
+```
+
+#### [`immer`](https://github.com/mweststrate/immer#api)
+
+Our `createReducer` function already uses Immer to allow for easier immutable updates in reduces, but you can also install it and use `createNextState` directly (also commonly referred to as `produce`).
+
+#### [`redux`](https://github.com/reactjs/redux)
+
+We handle the tricky parts and majority of the boilerplate of configuring a Redux store with `configureStore`, but Redux has several other utility functions built in that you may find useful. `combineReducers` is called by `configureStore` internally, but you may wish to call it yourself to compose multiple levels of slice reducers. `compose` is a functional programming utility that composes functions from right to left. You might want to use it to apply several store custom enhancers/ functions in a row.

--- a/README.md
+++ b/README.md
@@ -186,11 +186,9 @@ const todosReducer = createReducer([], {
 
 While `redux-starter-kit` automatically sets up a store for you with recommended middlewares and some additional helper functions, we have recommendations for optional packages that you may find useful in your Redux application code.
 
-#### [`selectorator`](https://github.com/planttheidea/selectorator)
+#### [`selectorator`](https://github.com/planttheidea/selectorator#usage)
 
 It acts as a superset of the standard `createSelector` function from [Reselect](https://github.com/reactjs/reselect). The primary improvements are the ability to define "input selectors" using string keypaths, or return an object result based on an object of keypaths. It also accepts an object of customization options for more specific use cases.
-
-For more specifics, see the [`selectorator` usage documentation](https://github.com/planttheidea/selectorator#usage).
 
 ```js
 function createSelector(

--- a/README.md
+++ b/README.md
@@ -25,7 +25,6 @@ This package is _not_ intended to solve every possible complaint about Redux, an
 
 * A `configureStore()` function with simplified configuration options. It can automatically combine your slice reducers, adds whatever Redux middleware you supply, includes `redux-thunk` by default, and enables use of the Redux DevTools Extension.
 * A `createReducer()` utility that lets you supply a lookup table of action types to case reducer functions, rather than writing switch statements. In addition, it automatically uses the [`immer` library](https://github.com/mweststrate/immer) to let you write simpler immutable updates with normal mutative code, like `state.todos[3].completed = true`.
-* An improved version of the widely used `createSelector` utility for creating memoized selector functions, which can accept string keypaths as "input selectors" (re-exported from the [`selectorator` library](https://github.com/planttheidea/selectorator)).
 
 ### API Reference
 
@@ -182,59 +181,3 @@ const todosReducer = createReducer([], {
   TOGGLE_TODO: toggleTodo
 })
 ```
-
-#### `createSelector`
-
-The `createSelector` utility from the [`selectorator` library](https://github.com/planttheidea/selectorator), re-exported for ease of use. It acts as a superset of the standard `createSelector` function from [Reselect](https://github.com/reactjs/reselect). The primary improvements are the ability to define "input selectors" using string keypaths, or return an object result based on an object of keypaths. It also accepts an object of customization options for more specific use cases.
-
-For more specifics, see the [`selectorator` usage documentation](https://github.com/planttheidea/selectorator#usage).
-
-```js
-function createSelector(
-    // Can either be:
-    //    - An array containing selector functions, string keypaths, and argument objects
-    //    - An object whose keys are selector functions and string keypaths
-    paths : Array<Function | string | Object> | Object<string, string | Function>
-)
-```
-
-Example usage:
-
-```js
-// Define input selector using a string keypath
-const getSubtotal = createSelector(['shop.items'], items => {
-  // return value here
-})
-
-// Define input selectors as a mix of other selectors and string keypaths
-const getTax = createSelector(
-  [getSubtotal, 'shop.taxPercent'],
-  (subtotal, taxPercent) => {
-    // return value here
-  }
-)
-
-// Define input selector using a custom argument index to access a prop
-const getTabContent = createSelector(
-  [{ path: 'tabIndex', argIndex: 1 }],
-  tabIndex => {
-    // return value here
-  }
-)
-
-const getContents = createSelector({ foo: 'foo', bar: 'nested.bar' })
-// Returns an object like:  {foo, bar}
-```
-
-#### `createNextState`
-
-The default immutable update function from the [`immer` library](https://github.com/mweststrate/immer#api), re-exported here as `createNextState` (also commonly referred to as `produce`)
-
-#### `combineReducers`
-
-Redux's `combineReducers`, re-exported for convenience. While `configureStore` calls this internally, you may wish to call it yourself to compose multiple levels of slice reducers.
-
-#### `compose`
-
-Redux's `compose`. It composes functions from right to left.
-This is a functional programming utility. You might want to use it to apply several store custom enhancers/ functions in a row.

--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ const getContents = createSelector({ foo: 'foo', bar: 'nested.bar' })
 
 #### [`immer`](https://github.com/mweststrate/immer#api)
 
-Our `createReducer` function already uses Immer to allow for easier immutable updates in reduces, but you can also install it and use `createNextState` directly (also commonly referred to as `produce`).
+Our `createReducer` function already uses Immer to allow for easier immutable updates in reducers, but you can also install it and use `createNextState` directly (also commonly referred to as `produce`).
 
 #### [`redux`](https://github.com/reactjs/redux)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1408,11 +1408,6 @@
       "integrity": "sha1-wFNHeBfIa1HaqFPIHgWbcz0CNhQ=",
       "dev": true
     },
-    "fast-equals": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/fast-equals/-/fast-equals-1.2.1.tgz",
-      "integrity": "sha512-7Rgsev90v//xCp60nlc1zjx6POzONKkCgAnId9qCUFONQ8r/Y/M2QQvAmy7mQyHBOHgp5t/lQvvJzKpM4YQvxA=="
-    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -1651,14 +1646,6 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
       "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
       "dev": true
-    },
-    "identitate": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/identitate/-/identitate-1.0.0.tgz",
-      "integrity": "sha512-ZPOPADqYtQKzj4BEDXA74jSogtltI6W1qQBO8qk4mFr5+hg3vijnICic9fi5lDy0L1cDM1O1hjMkx6MINbsOGQ==",
-      "requires": {
-        "pathington": "1.1.5"
-      }
     },
     "ignore": {
       "version": "3.3.7",
@@ -2353,11 +2340,6 @@
         "pify": "2.3.0"
       }
     },
-    "pathington": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/pathington/-/pathington-1.1.5.tgz",
-      "integrity": "sha512-lDBQm2mJjMgL+tL/y2xpa/2fm1PVA6jtzGGZcTVXWQt0X3UwJbyoalQsl+PoNpdduuGiAp7zmVNuRaoYyhAYew=="
-    },
     "pify": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
@@ -2668,11 +2650,6 @@
         "resolve-from": "1.0.1"
       }
     },
-    "reselect": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/reselect/-/reselect-3.0.1.tgz",
-      "integrity": "sha1-79qpjqdFEyTQkrKyFjpqHXqaIUc="
-    },
     "resolve": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
@@ -2811,17 +2788,6 @@
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
       "integrity": "sha512-kKvNJn6Mm93gAczWVJg7wH+wGYWNrDHdWvpUmHyEsgCtIwwo3bqPtV4tR5tuPaUhTOo/kvhVwd8XwwOllGYkbg==",
       "dev": true
-    },
-    "selectorator": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/selectorator/-/selectorator-3.3.0.tgz",
-      "integrity": "sha512-GZX1biSrT1CpAeDaBjnRxbnjDys9JULX90jdxucESHkrOrKoVCYlw+ch5DDWlOuyI6Z/TxtsJXU5kaqchO7v+g==",
-      "requires": {
-        "fast-equals": "1.2.1",
-        "identitate": "1.0.0",
-        "reselect": "3.0.1",
-        "unchanged": "1.0.7"
-      }
     },
     "semver": {
       "version": "5.5.0",
@@ -3090,14 +3056,6 @@
       "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-0.7.17.tgz",
       "integrity": "sha512-uRdSdu1oA1rncCQL7sCj8vSyZkgtL7faaw9Tc9rZ3mGgraQ7+Pdx7w5mnOSF3gw9ZNG6oc+KXfkon3bKuROm0g==",
       "dev": true
-    },
-    "unchanged": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/unchanged/-/unchanged-1.0.7.tgz",
-      "integrity": "sha512-/Dm88iLAglgEp2SFc3ohezG5HRYVydSBZCUo45jeNoQd1Y4bTJ8xmZVkGX60qqaF07KIjYR06+0Dj41Im76oOg==",
-      "requires": {
-        "pathington": "1.1.5"
-      }
     },
     "util-deprecate": {
       "version": "1.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5373,12 +5373,8 @@
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-    },
-    "lodash-es": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
-      "integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -6260,20 +6256,18 @@
       }
     },
     "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
+      "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
       "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
         "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
+        "symbol-observable": "^1.2.0"
       }
     },
     "redux-devtools-extension": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.2.tgz",
-      "integrity": "sha1-4Pmo6N/KfBe+kscSSVijuU6ykR0="
+      "version": "2.13.5",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.5.tgz",
+      "integrity": "sha512-QQ9BRy77oURHMdGys9rfQcCQDzXZ1T4oW+eUyE5Cg7DNVau69HJzc4YNDMOmpi0Dzpi1zOQgQ2rUpgJta4Lfqg=="
     },
     "redux-thunk": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
     "immer": "^1.1.1",
     "redux": "^3.7.2",
     "redux-devtools-extension": "^2.13.2",
-    "redux-thunk": "^2.2.0",
-    "selectorator": "^3.3.0"
+    "redux-thunk": "^2.2.0"
   }
 }

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,2 @@
 export { configureStore, getDefaultMiddleware } from './configureStore'
 export { createReducer } from './createReducer'
-
-export { default as createNextState } from 'immer'
-export { combineReducers } from 'redux'
-export { default as createSelector } from 'selectorator'


### PR DESCRIPTION
Fixes #19, please refer to it for my rationale.

I removed the dependency on selectorator and some re-exports of Immer and Redux functions. The goal is not to discourage their use, but encourage users to install companion packages separate for more flexible versioning and so they're not locked into the versions bundled with this package. I tried to preserve the docs for the formerly re-exported functions, but I'm not sure about the placement within the readme and wording, so I'm open to suggestions.