### PR TITLE
Install Redux 4 and compatible versions of DevTools extension

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5386,12 +5386,8 @@
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
-    },
-    "lodash-es": {
-      "version": "4.17.5",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.5.tgz",
-      "integrity": "sha512-Ez3ONp3TK9gX1HYKp6IhetcVybD+2F+Yp6GS9dfH8ue6EOCEzQtQEh4K0FYWBP9qLv+lzeQAYXw+3ySfxyZqkw=="
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "dev": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -6278,20 +6274,18 @@
       }
     },
     "redux": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/redux/-/redux-3.7.2.tgz",
-      "integrity": "sha512-pNqnf9q1hI5HHZRBkj3bAngGZW/JMCmexDlOxw4XagXY2o1327nHH54LoTjiPJ0gizoqPDRqWyX/00g0hD6w+A==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/redux/-/redux-4.0.0.tgz",
+      "integrity": "sha512-NnnHF0h0WVE/hXyrB6OlX67LYRuaf/rJcbWvnHHEPCF/Xa/AZpwhs/20WyqzQae5x4SD2F9nPObgBh2rxAgLiA==",
       "requires": {
-        "lodash": "^4.2.1",
-        "lodash-es": "^4.2.1",
         "loose-envify": "^1.1.0",
-        "symbol-observable": "^1.0.3"
+        "symbol-observable": "^1.2.0"
       }
     },
     "redux-devtools-extension": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.2.tgz",
-      "integrity": "sha1-4Pmo6N/KfBe+kscSSVijuU6ykR0="
+      "version": "2.13.5",
+      "resolved": "https://registry.npmjs.org/redux-devtools-extension/-/redux-devtools-extension-2.13.5.tgz",
+      "integrity": "sha512-QQ9BRy77oURHMdGys9rfQcCQDzXZ1T4oW+eUyE5Cg7DNVau69HJzc4YNDMOmpi0Dzpi1zOQgQ2rUpgJta4Lfqg=="
     },
     "redux-thunk": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -40,8 +40,8 @@
   ],
   "dependencies": {
     "immer": "^1.1.3",
-    "redux": "^3.7.2",
-    "redux-devtools-extension": "^2.13.2",
+    "redux": "^4.0.0",
+    "redux-devtools-extension": "^2.13.3",
     "redux-thunk": "^2.2.0",
     "selectorator": "^3.3.0"
   },


### PR DESCRIPTION
Fixes #28, Redux 4 should now be fully supported. Tested by running `npm install` with no peer dependency warnings and successfully running the [example](https://github.com/markerikson/redux-starter-kit/pull/11) (after updating React Redux).